### PR TITLE
Fix MLflow run lifecycle for issue #4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
       - run: python -m unittest discover -s tests -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - run: python -m unittest discover -s tests -v
+      - run: python -m compileall -q automation

--- a/automation/tracking.py
+++ b/automation/tracking.py
@@ -3,10 +3,13 @@ import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Sequence, Tuple
+
+import torch
 from mlflow.entities import Run
 from mlflow.tracking import MlflowClient
-import torch
+
 from .workflows import load_tracking
+
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 CONFIG = load_tracking()
 ENABLED = bool(CONFIG.get("enabled", False))
@@ -19,61 +22,85 @@ LIST_LIMIT = int(CONFIG.get("list_limit", 20))
 CLIENT: MlflowClient | None = None
 EXPERIMENT_ID: str | None = None
 TRACKING_URI: str | None = None
+
+
 def _utc_iso(moment: datetime) -> str:
     return moment.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
 def _local_iso(moment: datetime) -> str:
     return moment.astimezone().isoformat()
+
+
 def _tracking_path() -> Path:
     path = PROJECT_ROOT / ARTIFACT_DIR
     path.mkdir(parents=True, exist_ok=True)
     return path.resolve()
+
+
 def _client() -> Tuple[MlflowClient, str, str]:
     global CLIENT, EXPERIMENT_ID, TRACKING_URI
     if CLIENT is not None and EXPERIMENT_ID is not None and TRACKING_URI is not None:
         return CLIENT, EXPERIMENT_ID, TRACKING_URI
-    path = _tracking_path()
-    uri = path.as_uri()
+    uri = _tracking_path().as_uri()
     client = MlflowClient(tracking_uri=uri)
     experiment = client.get_experiment_by_name(EXPERIMENT_NAME)
-    if experiment:
-        experiment_id = experiment.experiment_id
-    else:
-        experiment_id = client.create_experiment(EXPERIMENT_NAME)
+    experiment_id = experiment.experiment_id if experiment else client.create_experiment(EXPERIMENT_NAME)
     CLIENT = client
     EXPERIMENT_ID = experiment_id
     TRACKING_URI = uri
     return client, experiment_id, uri
+
+
 def _stringify_params(values: Dict[str, Any]) -> Dict[str, str]:
-    result: Dict[str, str] = {}
-    for key, value in values.items():
-        if isinstance(value, (dict, list, tuple, set)):
-            result[key] = json.dumps(value, ensure_ascii=False)
-        else:
-            result[key] = str(value)
-    return result
+    return {
+        key: json.dumps(value, ensure_ascii=False) if isinstance(value, (dict, list, tuple, set)) else str(value)
+        for key, value in values.items()
+    }
+
+
 def _gpu_tags() -> Dict[str, str]:
     if not torch.cuda.is_available():
-        return {
-            "gpu_available": "false",
-        }
-    count = torch.cuda.device_count()
-    tags: Dict[str, str] = {
+        return {"gpu_available": "false"}
+    tags = {
         "gpu_available": "true",
-        "gpu_device_count": str(count),
+        "gpu_device_count": str(torch.cuda.device_count()),
     }
-    if count > 0:
-        name = torch.cuda.get_device_name(0)
-        total = torch.cuda.get_device_properties(0).total_memory
-        tags["gpu_primary_name"] = name
-        tags["gpu_primary_total_vram_bytes"] = str(total)
+    if torch.cuda.device_count():
+        tags["gpu_primary_name"] = torch.cuda.get_device_name(0)
+        tags["gpu_primary_total_vram_bytes"] = str(torch.cuda.get_device_properties(0).total_memory)
     return tags
+
+
+def _outcome(history: Dict[str, Any]) -> tuple[str, Dict[str, Any] | None]:
+    status = history.get("status") or {}
+    if status.get("status_str") != "error":
+        return "FINISHED", None
+    payload = None
+    interrupted = False
+    for entry in status.get("messages") or []:
+        if not isinstance(entry, (list, tuple)) or len(entry) < 2:
+            continue
+        event, data = entry[0], entry[1]
+        if event == "execution_error" and isinstance(data, dict):
+            payload = data
+        if event == "execution_interrupted":
+            interrupted = True
+            if isinstance(data, dict):
+                payload = data
+    return ("KILLED" if interrupted else "FAILED"), payload
+
+
 class NullSession:
     def log_window(self, window_start: datetime) -> None:
         return
+
     def set_start(self, moment: datetime) -> None:
         return
+
     def log_queue(self, prompt_id: str) -> None:
         return
+
     def log_completion(
         self,
         elapsed: float,
@@ -83,6 +110,8 @@ class NullSession:
         history: Dict[str, Any],
     ) -> None:
         return
+
+
 class TrackingSession:
     def __init__(
         self,
@@ -96,12 +125,11 @@ class TrackingSession:
         schedule_mode: str,
     ) -> None:
         client, experiment_id, _ = _client()
-        stamp = datetime.utcnow().strftime("%Y%m%d-%H%M%S")
         run_name = RUN_NAME_PATTERN.format(
             mode=mode,
             preset=preset or "none",
             digest=digest,
-            stamp=stamp,
+            stamp=datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S"),
         )
         tags = {
             "mode": mode,
@@ -111,29 +139,28 @@ class TrackingSession:
             "prompt_words": str(len(enriched_prompt.split())),
         }
         tags.update(_gpu_tags())
-        run = client.create_run(
-            experiment_id=experiment_id,
-            tags=tags,
-            run_name=run_name,
-        )
+        run = client.create_run(experiment_id=experiment_id, tags=tags, run_name=run_name)
         self.client = client
         self.run_id = run.info.run_id
         self.parameters = parameters
         for key, value in _stringify_params(parameters).items():
-            self.client.log_param(self.run_id, key, value)
-        self.client.log_text(self.run_id, prompt, "prompt_input.txt")
-        self.client.log_text(self.run_id, enriched_prompt, "prompt_enriched.txt")
-        self.client.log_dict(self.run_id, workflow, "workflow.json")
+            client.log_param(self.run_id, key, value)
+        client.log_text(self.run_id, prompt, "prompt_input.txt")
+        client.log_text(self.run_id, enriched_prompt, "prompt_enriched.txt")
+        client.log_dict(self.run_id, workflow, "workflow.json")
         self.start_time: datetime | None = None
+
     def log_window(self, window_start: datetime) -> None:
         self.client.set_tag(self.run_id, "window_start_utc", _utc_iso(window_start))
         self.client.set_tag(self.run_id, "window_start_local", _local_iso(window_start))
+
     def set_start(self, moment: datetime) -> None:
-        utc_start = moment.replace(tzinfo=timezone.utc)
-        self.start_time = utc_start
-        self.client.set_tag(self.run_id, "execution_start_utc", _utc_iso(utc_start))
+        self.start_time = moment.replace(tzinfo=timezone.utc)
+        self.client.set_tag(self.run_id, "execution_start_utc", _utc_iso(self.start_time))
+
     def log_queue(self, prompt_id: str) -> None:
         self.client.set_tag(self.run_id, "prompt_id", prompt_id)
+
     def log_completion(
         self,
         elapsed: float,
@@ -143,28 +170,31 @@ class TrackingSession:
         history: Dict[str, Any],
     ) -> None:
         utc_end = end_time.replace(tzinfo=timezone.utc)
-        frames_value = float(self.parameters.get("frames", 0) or 0)
-        fps = frames_value / elapsed if elapsed > 0 and frames_value else 0.0
+        frames = float(self.parameters.get("frames", 0) or 0)
         self.client.log_metric(self.run_id, "elapsed_seconds", elapsed)
-        if fps:
-            self.client.log_metric(self.run_id, "fps", fps)
+        if elapsed > 0 and frames:
+            self.client.log_metric(self.run_id, "fps", frames / elapsed)
         self.client.set_tag(self.run_id, "execution_end_utc", _utc_iso(utc_end))
         if self.start_time:
             self.client.set_tag(self.run_id, "execution_start_epoch", str(int(self.start_time.timestamp())))
         self.client.set_tag(self.run_id, "execution_end_epoch", str(int(utc_end.timestamp())))
         self.client.set_tag(self.run_id, "output_nodes", ",".join(nodes))
-        self.client.set_tag(
-            self.run_id,
-            "output_paths",
-            json.dumps([str(path) for path in paths], ensure_ascii=False),
-        )
+        self.client.set_tag(self.run_id, "output_paths", json.dumps(list(paths), ensure_ascii=False))
         self.client.log_dict(self.run_id, history, "history.json")
         for path in paths:
             file_path = Path(path)
             if not file_path.is_absolute():
-                file_path = PROJECT_ROOT / path
+                file_path = PROJECT_ROOT / file_path
             if file_path.exists():
                 self.client.log_artifact(self.run_id, str(file_path))
+        status, error = _outcome(history)
+        if error:
+            self.client.log_dict(self.run_id, error, "error.json")
+            self.client.set_tag(self.run_id, "error_type", str(error.get("exception_type", "")))
+            self.client.set_tag(self.run_id, "error_message", str(error.get("exception_message", "")))
+        self.client.set_terminated(self.run_id, status=status)
+
+
 def create_session(
     mode: str,
     preset: str | None,
@@ -187,110 +217,109 @@ def create_session(
         workflow=workflow,
         schedule_mode=schedule_mode,
     )
+
+
 def _format_run_line(run: Run) -> str:
+    start = datetime.fromtimestamp((run.info.start_time or 0) / 1000, timezone.utc)
     data = run.data
-    start_ms = run.info.start_time or 0
-    start = datetime.fromtimestamp(start_ms / 1000, timezone.utc)
-    elapsed = data.metrics.get("elapsed_seconds", 0.0)
-    mode = data.tags.get("mode", "")
-    preset = data.tags.get("preset", "")
-    prompt_digest = data.tags.get("prompt_digest", "")
-    return f"{run.info.run_id} | {start.isoformat()} | {mode} | {preset} | {elapsed:.2f}s | {prompt_digest}"
-def _print_run_paths(run: Run) -> None:
-    paths = run.data.tags.get("output_paths")
-    if not paths:
-        return
-    decoded = json.loads(paths)
-    for entry in decoded:
-        print(f"  artifact: {entry}")
-def _list_runs(client: MlflowClient, experiment_id: str) -> None:
-    runs = client.search_runs(
-        experiment_ids=[experiment_id],
-        order_by=["attributes.start_time DESC"],
-        max_results=LIST_LIMIT,
+    return (
+        f"{run.info.run_id} | {start.isoformat()} | {data.tags.get('mode', '')} | "
+        f"{data.tags.get('preset', '')} | {data.metrics.get('elapsed_seconds', 0.0):.2f}s | "
+        f"{data.tags.get('prompt_digest', '')}"
     )
+
+
+def _print_run_paths(run: Run) -> None:
+    for entry in json.loads(run.data.tags.get("output_paths") or "[]"):
+        print(f"  artifact: {entry}")
+
+
+def _runs(client: MlflowClient, experiment_id: str) -> List[Run]:
+    return list(
+        client.search_runs(
+            experiment_ids=[experiment_id],
+            order_by=["attributes.start_time DESC"],
+            max_results=LIST_LIMIT,
+        )
+    )
+
+
+def _list_runs(client: MlflowClient, experiment_id: str) -> None:
+    runs = _runs(client, experiment_id)
     if not runs:
         print("No experiments.")
         return
     for run in runs:
         print(_format_run_line(run))
         _print_run_paths(run)
+
+
 def _stats(client: MlflowClient, experiment_id: str) -> None:
-    runs = client.search_runs(
-        experiment_ids=[experiment_id],
-        order_by=["attributes.start_time DESC"],
-        max_results=LIST_LIMIT,
-    )
-    if not runs:
+    runs = _runs(client, experiment_id)
+    durations = [run.data.metrics["elapsed_seconds"] for run in runs if "elapsed_seconds" in run.data.metrics]
+    if not durations:
         print("No experiments.")
         return
-    durations = [run.data.metrics.get("elapsed_seconds", 0.0) for run in runs if run.data.metrics.get("elapsed_seconds")]
-    if durations:
-        avg = sum(durations) / len(durations)
-        print(f"Average elapsed_seconds: {avg:.2f}")
-        print(f"Min elapsed_seconds: {min(durations):.2f}")
-        print(f"Max elapsed_seconds: {max(durations):.2f}")
+    print(f"Average elapsed_seconds: {sum(durations) / len(durations):.2f}")
+    print(f"Min elapsed_seconds: {min(durations):.2f}")
+    print(f"Max elapsed_seconds: {max(durations):.2f}")
     presets: Dict[str, List[float]] = {}
     for run in runs:
-        preset = run.data.tags.get("preset") or "default"
-        if run.data.metrics.get("elapsed_seconds"):
-            presets.setdefault(preset, []).append(run.data.metrics["elapsed_seconds"])
+        if "elapsed_seconds" in run.data.metrics:
+            presets.setdefault(run.data.tags.get("preset") or "default", []).append(run.data.metrics["elapsed_seconds"])
     for preset, values in presets.items():
-        avg = sum(values) / len(values)
-        print(f"{preset}: count={len(values)} avg={avg:.2f}")
+        print(f"{preset}: count={len(values)} avg={sum(values) / len(values):.2f}")
+
+
 def _compare(client: MlflowClient, run_ids: Sequence[str]) -> None:
     if len(run_ids) < 2:
         print("Need two run ids.")
         return
-    run_a = client.get_run(run_ids[0])
-    run_b = client.get_run(run_ids[1])
-    keys = sorted(set(run_a.data.params) | set(run_b.data.params))
+    left = client.get_run(run_ids[0])
+    right = client.get_run(run_ids[1])
     print(f"Comparing {run_ids[0]} vs {run_ids[1]}")
-    for key in keys:
-        left = run_a.data.params.get(key, "-")
-        right = run_b.data.params.get(key, "-")
-        marker = "!=" if left != right else "=="
-        print(f"{key}: {left} {marker} {right}")
-    metric_keys = sorted(set(run_a.data.metrics) | set(run_b.data.metrics))
-    for key in metric_keys:
-        left = run_a.data.metrics.get(key, "-")
-        right = run_b.data.metrics.get(key, "-")
-        marker = "!=" if left != right else "=="
-        print(f"{key}: {left} {marker} {right}")
+    for key in sorted(set(left.data.params) | set(right.data.params)):
+        a = left.data.params.get(key, "-")
+        b = right.data.params.get(key, "-")
+        print(f"{key}: {a} {'!=' if a != b else '=='} {b}")
+    for key in sorted(set(left.data.metrics) | set(right.data.metrics)):
+        a = left.data.metrics.get(key, "-")
+        b = right.data.metrics.get(key, "-")
+        print(f"{key}: {a} {'!=' if a != b else '=='} {b}")
+
+
 def handle_cli(args: Sequence[str]) -> None:
     if not ENABLED:
         print("Tracking disabled.")
         return
     client, experiment_id, uri = _client()
     if not args:
-        subprocess.run([
-            "uv",
-            "run",
-            "mlflow",
-            "ui",
-            "--backend-store-uri",
-            uri,
-            "--default-artifact-root",
-            uri,
-            "--host",
-            UI_HOST,
-            "--port",
-            str(UI_PORT),
-        ])
+        subprocess.run(
+            [
+                "uv",
+                "run",
+                "mlflow",
+                "ui",
+                "--backend-store-uri",
+                uri,
+                "--default-artifact-root",
+                uri,
+                "--host",
+                UI_HOST,
+                "--port",
+                str(UI_PORT),
+            ],
+            check=False,
+        )
         return
-    head = args[0]
-    tail = args[1:]
+    head, *tail = args
     if head == "--list":
         _list_runs(client, experiment_id)
-        return
-    if head == "--stats":
+    elif head == "--stats":
         _stats(client, experiment_id)
-        return
-    if head == "--compare":
+    elif head == "--compare":
         _compare(client, tail)
-        return
-    if head == "--artifacts" and tail:
-        run = client.get_run(tail[0])
-        _print_run_paths(run)
-        return
-    print("Unknown experiments command.")
+    elif head == "--artifacts" and tail:
+        _print_run_paths(client.get_run(tail[0]))
+    else:
+        print("Unknown experiments command.")

--- a/tests/test_tracking_contract.py
+++ b/tests/test_tracking_contract.py
@@ -1,0 +1,54 @@
+import ast
+import unittest
+from pathlib import Path
+from typing import Any, Dict
+
+
+class TrackingContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.path = Path(__file__).resolve().parents[1] / "automation" / "tracking.py"
+        cls.source = cls.path.read_text(encoding="utf-8")
+        cls.tree = ast.parse(cls.source)
+        outcome = next(
+            node
+            for node in cls.tree.body
+            if isinstance(node, ast.FunctionDef) and node.name == "_outcome"
+        )
+        namespace = {"Any": Any, "Dict": Dict}
+        exec(compile(ast.Module(body=[outcome], type_ignores=[]), str(cls.path), "exec"), namespace)
+        cls.outcome = staticmethod(namespace["_outcome"])
+
+    def test_success_maps_to_finished(self) -> None:
+        self.assertEqual(self.outcome({"status": {"status_str": "success"}}), ("FINISHED", None))
+
+    def test_execution_error_maps_to_failed_and_keeps_payload(self) -> None:
+        error = {"exception_type": "RuntimeError", "exception_message": "boom"}
+        history = {
+            "status": {
+                "status_str": "error",
+                "messages": [["execution_error", error]],
+            }
+        }
+        self.assertEqual(self.outcome(history), ("FAILED", error))
+
+    def test_interruption_maps_to_killed(self) -> None:
+        payload = {"node_id": "7"}
+        history = {
+            "status": {
+                "status_str": "error",
+                "messages": [["execution_interrupted", payload]],
+            }
+        }
+        self.assertEqual(self.outcome(history), ("KILLED", payload))
+
+    def test_mlflow_runs_are_explicitly_terminated(self) -> None:
+        self.assertIn("set_terminated", self.source)
+        self.assertIn('"error.json"', self.source)
+        self.assertIn('"elapsed_seconds"', self.source)
+        self.assertIn('"fps"', self.source)
+        self.assertIn('"workflow.json"', self.source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #4

## 変更
- MLflow低レベル `create_run` で作成したrunを、ComfyUI historyの終了状態に応じて `FINISHED` / `FAILED` / `KILLED` で明示的に終端
- `execution_error` / `execution_interrupted` のpayloadを `error.json` とtagへ保存
- 既存のparameters、elapsed_seconds、fps、workflow/history/output artifact、GPU/VRAM tag、JSONL運用は維持
- 成功・失敗・interruptのstatus mappingを検証するstdlibのみのcontract testを追加
- GitHub Actions CIを追加（Python 3.11、unittest、compileall）

## 検証
- `python -m unittest discover -s tests -v`: 4 tests PASS
- `python -m compileall -q automation`: PASS
- 実GPU生成はモデルassetを必要とするため今回のCIでは実行しない

## CI
- `actions/checkout@v7`
- `actions/setup-python@v7`

追加asset/API key: なし